### PR TITLE
wire resolver dependencies directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 build:
 	go build .
 
+test:
+	go test ./models ./resolvers ./rules
+
 docker:
 	docker build -t formomosan/go_stop:latest . -f Dockerfile

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"github.com/camirmas/go_stop/models"
+	"github.com/camirmas/go_stop/resolvers"
 	"github.com/graphql-go/graphql"
 	"github.com/joho/godotenv"
 	"log"
@@ -63,17 +64,23 @@ func makeDb() *models.PostgresDB {
 	return db
 }
 
+func makeResolvers(db models.DB) *resolvers.Resolvers {
+	return resolvers.NewResolvers(db, getSigningKey())
+}
+
 func main() {
 	if err := godotenv.Load(); err != nil {
 		log.Fatal("Could not load .env", err)
 	}
 
-	schema, err := NewSchema()
+	db := makeDb()
+	resolvers := makeResolvers(db)
+
+	schema, err := NewSchema(resolvers)
 	if err != nil {
-		log.Fatal("Could not create GraphQL schema", err)
+		log.Fatal("Could not crete GraphQL schema", err)
 	}
 
-	db := makeDb()
 	s := makeServer(db, &schema)
 	s.Start()
 }

--- a/mutations.go
+++ b/mutations.go
@@ -5,7 +5,7 @@ import (
 	"github.com/graphql-go/graphql"
 )
 
-func buildMutations(objects *Objects) *graphql.Object {
+func buildMutations(resolvers *resolvers.Resolvers, objects *Objects) *graphql.Object {
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: "Mutation",
 		Fields: graphql.Fields{

--- a/queries.go
+++ b/queries.go
@@ -5,7 +5,7 @@ import (
 	"github.com/graphql-go/graphql"
 )
 
-func buildQueries(objects *Objects) *graphql.Object {
+func buildQueries(resolvers *resolvers.Resolvers, objects *Objects) *graphql.Object {
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: "Query",
 		Fields: graphql.Fields{

--- a/resolvers/game_test.go
+++ b/resolvers/game_test.go
@@ -13,28 +13,28 @@ func TestCreateGame(t *testing.T) {
 }
 
 func createGameInvalidToken(t *testing.T) {
-	params := setup()
+	r, params := setup()
 	params.Context = context.WithValue(params.Context, "token", nil)
 
-	_, err := CreateGame(params)
+	_, err := r.CreateGame(params)
 
 	expectErr(t, invalidTokenError{}, err)
 }
 
 func createGameSelf(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["opponentUsername"] = "dude"
 
-	_, err := CreateGame(params)
+	_, err := r.CreateGame(params)
 
 	expectErr(t, sameUserError{}, err)
 }
 
 func createGame(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["opponentUsername"] = "saitama"
 
-	_, err := CreateGame(params)
+	_, err := r.CreateGame(params)
 
 	if err != nil {
 		t.Errorf("Expected new game, got error: %s", err.Error())
@@ -42,10 +42,10 @@ func createGame(t *testing.T) {
 }
 
 func TestGetGame(t *testing.T) {
-	params := setup()
+	r, params := setup()
 	params.Args["id"] = "1"
 
-	game, err := GetGame(params)
+	game, err := r.GetGame(params)
 
 	if err != nil {
 		t.Errorf("Expected Game, got error: %s", err.Error())
@@ -57,10 +57,10 @@ func TestGetGame(t *testing.T) {
 }
 
 func TestGetGames(t *testing.T) {
-	params := setup()
+	r, params := setup()
 	params.Args["userId"] = "1"
 
-	games, err := GetGames(params)
+	games, err := r.GetGames(params)
 
 	if err != nil {
 		t.Error("Expected Games, got error")
@@ -72,9 +72,9 @@ func TestGetGames(t *testing.T) {
 }
 
 func TestGetLobby(t *testing.T) {
-	params := setup()
+	r, params := setup()
 
-	games, err := GetLobby(params)
+	games, err := r.GetLobby(params)
 
 	if err != nil {
 		t.Error("Expected Games, got error")
@@ -94,46 +94,46 @@ func TestPass(t *testing.T) {
 }
 
 func passInvalidToken(t *testing.T) {
-	params := setup()
+	r, params := setup()
 	params.Context = context.WithValue(params.Context, "token", nil)
 
-	_, err := Pass(params)
+	_, err := r.Pass(params)
 
 	expectErr(t, invalidTokenError{}, err)
 }
 
 func passComplete(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "2"
 
-	_, err := Pass(params)
+	_, err := r.Pass(params)
 
 	expectErr(t, gameCompleteError{}, err)
 }
 
 func passInvalidTurn(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "3"
 
-	_, err := Pass(params)
+	_, err := r.Pass(params)
 
 	expectErr(t, wrongTurnError{}, err)
 }
 
 func passNotInGame(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "10"
 
-	_, err := Pass(params)
+	_, err := r.Pass(params)
 
 	expectErr(t, userNotInGameError{}, err)
 }
 
 func pass(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "4"
 
-	game, err := Pass(params)
+	game, err := r.Pass(params)
 
 	if err != nil {
 		t.Errorf("Expected Game, got error: %s", err.Error())
@@ -153,48 +153,48 @@ func TestAddStone(t *testing.T) {
 }
 
 func addStoneInvalidToken(t *testing.T) {
-	params := setup()
+	r, params := setup()
 	params.Context = context.WithValue(params.Context, "token", nil)
 
-	_, err := AddStone(params)
+	_, err := r.AddStone(params)
 
 	expectErr(t, invalidTokenError{}, err)
 }
 
 func addStoneComplete(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "2"
 
-	_, err := AddStone(params)
+	_, err := r.AddStone(params)
 
 	expectErr(t, gameCompleteError{}, err)
 }
 
 func addStoneInvalidTurn(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "3"
 
-	_, err := AddStone(params)
+	_, err := r.AddStone(params)
 
 	expectErr(t, wrongTurnError{}, err)
 }
 
 func addStoneNotInGame(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "10"
 
-	_, err := AddStone(params)
+	_, err := r.AddStone(params)
 
 	expectErr(t, userNotInGameError{}, err)
 }
 
 func addStone(t *testing.T) {
-	params := setupAuth()
+	r, params := setupAuth()
 	params.Args["gameId"] = "4"
 	params.Args["x"] = 3
 	params.Args["y"] = 3
 
-	stone, err := AddStone(params)
+	stone, err := r.AddStone(params)
 
 	if err != nil {
 		t.Errorf("Expected Stone, got error: %s", err.Error())

--- a/resolvers/resolvers.go
+++ b/resolvers/resolvers.go
@@ -1,0 +1,15 @@
+package resolvers
+
+import "github.com/camirmas/go_stop/models"
+
+type Resolvers struct {
+	db         models.DB
+	signingKey []byte
+}
+
+func NewResolvers(db models.DB, signingKey []byte) *Resolvers {
+	return &Resolvers{
+		db,
+		signingKey,
+	}
+}

--- a/resolvers/user.go
+++ b/resolvers/user.go
@@ -9,44 +9,39 @@ import (
 )
 
 // GetUser gets a User by username.
-func GetUser(p graphql.ResolveParams) (interface{}, error) {
-	db := p.Context.Value("db").(models.DB)
-	return db.GetUser(p.Args["username"].(string))
+func (r *Resolvers) GetUser(p graphql.ResolveParams) (interface{}, error) {
+	return r.db.GetUser(p.Args["username"].(string))
 }
 
 // CreateUser creates a new User account.
-func CreateUser(p graphql.ResolveParams) (interface{}, error) {
-	db := p.Context.Value("db").(models.DB)
-	signingKey := p.Context.Value("signingKey").([]byte)
+func (r *Resolvers) CreateUser(p graphql.ResolveParams) (interface{}, error) {
 	username := p.Args["username"].(string)
 	email := p.Args["email"].(string)
 	password := p.Args["password"].(string)
 	passwordConfirm := p.Args["passwordConfirmation"].(string)
 
-	user, err := db.CreateUser(username, email, password, passwordConfirm)
+	user, err := r.db.CreateUser(username, email, password, passwordConfirm)
 
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := GenerateToken(user.Id, signingKey)
+	token, err := GenerateToken(user.Id, r.signingKey)
 
 	return &models.AuthUser{token, user}, nil
 }
 
 // LogIn generates a new JWT given a valid username/password.
-func LogIn(p graphql.ResolveParams) (interface{}, error) {
+func (r *Resolvers) LogIn(p graphql.ResolveParams) (interface{}, error) {
 	username := p.Args["username"].(string)
 	password := p.Args["password"].(string)
-	db := p.Context.Value("db").(models.DB)
-	signingKey := p.Context.Value("signingKey").([]byte)
-	user, err := db.CheckPw(username, password)
+	user, err := r.db.CheckPw(username, password)
 
 	if err != nil {
 		return nil, err
 	}
 
-	token, err := GenerateToken(user.Id, signingKey)
+	token, err := GenerateToken(user.Id, r.signingKey)
 
 	if err != nil {
 		return user, err
@@ -59,21 +54,18 @@ func LogIn(p graphql.ResolveParams) (interface{}, error) {
 
 // CurrentUser gets the user corresponding to the provided JWT from request
 // Content Headers.
-func CurrentUser(p graphql.ResolveParams) (interface{}, error) {
-	db := p.Context.Value("db").(models.DB)
-	signingKey := p.Context.Value("signingKey").([]byte)
-
+func (r *Resolvers) CurrentUser(p graphql.ResolveParams) (interface{}, error) {
 	token, ok := p.Context.Value("token").(string)
 
 	if !ok {
 		return nil, missingTokenError{}
 	}
 
-	claims, err := ValidateToken(token, signingKey)
+	claims, err := ValidateToken(token, r.signingKey)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return db.GetUser(claims.UserId)
+	return r.db.GetUser(claims.UserId)
 }

--- a/schema.go
+++ b/schema.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	_ "fmt"
+	"github.com/camirmas/go_stop/resolvers"
 	"github.com/graphql-go/graphql"
 )
 
-func NewSchema() (graphql.Schema, error) {
+func NewSchema(resolvers *resolvers.Resolvers) (graphql.Schema, error) {
 	objects := buildObjects()
 	schemaConfig := graphql.SchemaConfig{
-		Query:    buildQueries(objects),
-		Mutation: buildMutations(objects),
+		Query:    buildQueries(resolvers, objects),
+		Mutation: buildMutations(resolvers, objects),
 	}
 
 	return graphql.NewSchema(schemaConfig)

--- a/server.go
+++ b/server.go
@@ -41,16 +41,14 @@ func (s *Server) Start() {
 	})
 
 	log.Println("Listening on http://localhost:8000")
-	http.Handle("/graphql", applyMiddlewares(s, h))
+	http.Handle("/graphql", s.applyMiddlewares(h))
 	log.Fatal(http.ListenAndServe(":8000", nil))
 }
 
-func applyMiddlewares(s *Server, next *handler.Handler) http.Handler {
+func (s *Server) applyMiddlewares(next *handler.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		enableCors(&w)
-		ctx := context.WithValue(r.Context(), "db", s.db)
-		ctx = context.WithValue(ctx, "signingKey", s.config.signingKey)
-		ctx = authHandler(ctx, r)
+		ctx := authHandler(r.Context(), r)
 		next.ContextHandler(ctx, w, r)
 	})
 }


### PR DESCRIPTION
So when refactoring things I noticed the pattern to throw certain dependencies, such as the database, etc. into the context. This is kinda a code smell, mainly because we lose alot of compiler-enforced type safety, as we have to do typecasting in order to pull things out of the context.

Dependencies, such as the database model, should be wired through via struct constructors; this allows type-safe usage of said dependencies without having to assume that they exist in the context.