### PR TITLE
Add test suite instructions to contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,6 +9,22 @@ Install a version of Go `1.11` or higher -- `1.11` is needed for Go Module suppo
 
     $ go version
 
+Install and start PostgreSQL
+
+    $ psql -V
+
+Set up your PostgreSQL database:
+
+* Run `./script/bootstrap`, or:
+
+Create a `postgres` user
+
+    $ psql postgres -c 'CREATE ROLE postgres superuser;'
+
+Create the `go_stop_test` database:
+
+    $ createdb go_stop_test
+
 ### Running the test suite
 
-    $ go test
+    $ ./script/test

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,14 @@
+### Development setup
+
+_NOTE: This repository uses Go Modules, so it must be cloned **outside of your `$GOPATH`**._
+
+    $ cd <some/dir/outside/GOPATH>
+    $ git clone git@github.com:camirmas/go-stop-go.git
+
+Install a version of Go `1.11` or higher -- `1.11` is needed for Go Module support.
+
+    $ go version
+
+### Running the test suite
+
+    $ go test

--- a/models/database_test.go
+++ b/models/database_test.go
@@ -53,7 +53,7 @@ func setup() {
 	newDb, err := NewPostgresDB(config)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Could not connect to test Postgres database: %s", err)
 	}
 
 	db = newDb

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+psql postgres --command='CREATE ROLE postgres LOGIN;'
+createdb go_stop_test

--- a/script/test
+++ b/script/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+go test ./...


### PR DESCRIPTION
In order to run the test suite successfully:

* Go `1.11` must be installed
* The repository must be cloned _outside_ of your `$GOPATH`